### PR TITLE
Resolved issue with the recommended example

### DIFF
--- a/examples/minimumRecommended/minimumRecommended.ino
+++ b/examples/minimumRecommended/minimumRecommended.ino
@@ -19,8 +19,7 @@ void loop()
     gps.getDataGPRMC(latitud,
                     latitudHemisphere,
                     longitud,
-                    longitudMeridiano,
-                    );
+                    longitudMeridiano);
 
    Serial.println(latitud);
    Serial.println(latitudHemisphere);


### PR DESCRIPTION
There is a trailing comma in the minimumRecommended.ino example.